### PR TITLE
Add no-single-letter-variable rule to main export

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const rules = require("./lib");
+
 /**
  * TODO: If more distinct rulesets are needed, e.g. `plugin:curology/jest`,
  * `plugin:curology/react`, we can expand on the exported config keys.
@@ -75,4 +77,5 @@ module.exports = {
   configs: {
     recommended,
   },
+  rules,
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,5 @@
+const noSingleLetterVariable = require("./rules/no-single-letter-variable");
+
+module.exports = {
+  "no-single-letter-variable": noSingleLetterVariable,
+};


### PR DESCRIPTION
Needed to update `index.js` now that it exports both `config` and plugin `rules`.