### PR TITLE
Add cypress config

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,8 +73,22 @@ const recommended = {
   },
 };
 
+const cypress = {
+  extends: ["plugin:cypress/recommended"],
+  rules: {
+    "cypress/no-assigning-return-values": 2,
+    "cypress/no-unnecessary-waiting": 2,
+    "cypress/no-async-tests": 2,
+    "cypress/assertion-before-screenshot": 2,
+    "cypress/require-data-selectors": 0,
+    "cypress/no-force": 1,
+    "cypress/no-pause": 2,
+  },
+};
+
 module.exports = {
   configs: {
+    cypress,
     recommended,
   },
   rules,

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const recommended = {
   plugins: ["curology"],
   rules: {
     "@typescript-eslint/prefer-ts-expect-error": 2,
-    "arrow-parens": [2, "as-needed"],
+    "arrow-parens": 0,
     "class-methods-use-this": 0,
     "comma-dangle": [2, "always-multiline"],
     "consistent-return": 0,
@@ -74,8 +74,10 @@ const recommended = {
 };
 
 const cypress = {
-  extends: ["plugin:cypress/recommended"],
+  ...recommended,
+  extends: ["plugin:cypress/recommended", ...recommended.extends],
   rules: {
+    ...recommended.rules,
     "cypress/no-assigning-return-values": 2,
     "cypress/no-unnecessary-waiting": 2,
     "cypress/no-async-tests": 2,
@@ -83,6 +85,33 @@ const cypress = {
     "cypress/require-data-selectors": 0,
     "cypress/no-force": 1,
     "cypress/no-pause": 2,
+    "@typescript-eslint/ban-ts-ignore": "off",
+    "@typescript-eslint/camelcase": "off",
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        argsIgnorePattern: "^_",
+      },
+    ],
+    camelcase: "off",
+    "import/order": [
+      "error",
+      {
+        "newlines-between": "always",
+        pathGroups: [
+          {
+            pattern: "{constants,integration,fixtures}/**",
+            group: "parent",
+            position: "before",
+          },
+        ],
+        pathGroupsExcludedImportTypes: [],
+      },
+    ],
+  },
+  env: {
+    "cypress/globals": true,
   },
 };
 

--- a/index.js
+++ b/index.js
@@ -82,6 +82,7 @@ const recommended = {
 const cypress = {
   ...recommended,
   extends: ["plugin:cypress/recommended", ...recommended.extends],
+  parser: "@typescript-eslint/parser",
   plugins: ["cypress"],
   rules: {
     ...recommended.rules,

--- a/index.js
+++ b/index.js
@@ -1,5 +1,20 @@
 const rules = require("./lib");
 
+const importOrderBaseConfig = {
+  groups: [["builtin", "external"], "internal", ["parent", "sibling"]],
+  "newlines-between": "always",
+  warnOnUnassignedImports: false,
+};
+
+const importOrder = [
+  2,
+  {
+    groups: [["builtin", "external"], "internal", ["parent", "sibling"]],
+    "newlines-between": "always",
+    warnOnUnassignedImports: false,
+  },
+];
+
 /**
  * TODO: If more distinct rulesets are needed, e.g. `plugin:curology/jest`,
  * `plugin:curology/react`, we can expand on the exported config keys.
@@ -24,17 +39,11 @@ const recommended = {
     "function-paren-newline": 0,
     "global-require": 0,
     "id-length": 0,
-    "import/extensions": ["error", "never"],
+    "import/extensions": [2, "never"],
     "import/no-cycle": 1,
     "import/no-named-as-default-member": 1,
     "import/no-unresolved": 0,
-    "import/order": [
-      2,
-      {
-        groups: [["builtin", "external"], "internal", ["parent", "sibling"]],
-        "newlines-between": "always",
-      },
-    ],
+    "import/order": [2, { ...importOrderBaseConfig }],
     "import/prefer-default-export": 0,
     "import/no-extraneous-dependencies": [2, { devDependencies: true }],
     indent: 0,
@@ -51,10 +60,7 @@ const recommended = {
     "no-static-element-interactions": 0,
     "no-underscore-dangle": 1,
     "object-curly-newline": 0,
-    "object-property-newline": [
-      "error",
-      { allowAllPropertiesOnSameLine: true },
-    ],
+    "object-property-newline": [2, { allowAllPropertiesOnSameLine: true }],
     "react/function-component-definition": 0,
     "react/jsx-filename-extension": [1, { extensions: [".js", ".jsx"] }],
     "react/jsx-fragments": [2, "element"],
@@ -76,6 +82,7 @@ const recommended = {
 const cypress = {
   ...recommended,
   extends: ["plugin:cypress/recommended", ...recommended.extends],
+  plugins: ["cypress"],
   rules: {
     ...recommended.rules,
     "cypress/no-assigning-return-values": 2,
@@ -85,20 +92,20 @@ const cypress = {
     "cypress/require-data-selectors": 0,
     "cypress/no-force": 1,
     "cypress/no-pause": 2,
-    "@typescript-eslint/ban-ts-ignore": "off",
-    "@typescript-eslint/camelcase": "off",
-    "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/ban-ts-ignore": 0,
+    camelcase: 0,
+    "@typescript-eslint/camelcase": 0,
+    "@typescript-eslint/explicit-function-return-type": 0,
     "@typescript-eslint/no-unused-vars": [
-      "warn",
+      1,
       {
         argsIgnorePattern: "^_",
       },
     ],
-    camelcase: "off",
     "import/order": [
-      "error",
+      2,
       {
-        "newlines-between": "always",
+        ...importOrderBaseConfig,
         pathGroups: [
           {
             pattern: "{constants,integration,fixtures}/**",
@@ -109,6 +116,7 @@ const cypress = {
         pathGroupsExcludedImportTypes: [],
       },
     ],
+    "no-console": "off", // `cypress-log-to-output` makes console usage useful for debugging
   },
   env: {
     "cypress/globals": true,

--- a/package.json
+++ b/package.json
@@ -29,15 +29,16 @@
     "@typescript-eslint/parser": "^5.16.0",
     "eslint": "^8.11.0",
     "eslint-config-airbnb": "^19.0.4",
-    "eslint-config-prettier": "^8.1.0",
-    "eslint-import-resolver-webpack": "^0.13.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-import-resolver-webpack": "^0.13.2",
     "eslint-plugin-curology": "^0.1.0",
     "eslint-plugin-cypress": "^2.12.1",
-    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jest": "^26.1.2",
-    "eslint-plugin-jsx-a11y": "^6.4.1",
+    "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-prettier": "^4.0.0",
-    "eslint-plugin-react": "^7.22.0",
-    "eslint-plugin-react-hooks": "^4.2.0"
+    "eslint-plugin-react": "^7.29.4",
+    "eslint-plugin-react-hooks": "^4.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint-config-prettier": "^8.1.0",
     "eslint-import-resolver-webpack": "^0.13.0",
     "eslint-plugin-curology": "^0.1.0",
+    "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^26.1.2",
     "eslint-plugin-jsx-a11y": "^6.4.1",


### PR DESCRIPTION
Adds a `plugin:curology/cypress` config for us to share rules across all usages.

Next up: consolidating rulesets, not pulling in non-Cypress contexts into `cypress` (e.g. `react` rules).

Also bumps `peerDeps`.