### PR TITLE
[Hotfix] Correct Import Path

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-const rules = require("./lib/rules");
-const configs = require("./lib/configs");
+const rules = require("./src/rules");
+const configs = require("./src/configs");
 
 module.exports = {
   configs,


### PR DESCRIPTION
I replaced the previous `lib` setup with `src` to leave open the possibility of using TypeScript (and transpiling `src` to `lib` for usage). I forgot to correct the entry-point for actual downstream use though, so this PR fixes actual `eslint` CLI usage.

Will merge with breaking tests then fix the tests.