### PR TITLE
Fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-webpack": "^0.13.2",
-    "eslint-plugin-curology": "https://github.com/curology/eslint-plugin-curology.git#master",
+    "eslint-plugin-curology": "^1.0.2",
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jest": "^26.1.3",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-webpack": "^0.13.2",
+    "eslint-plugin-curology": "https://github.com/curology/eslint-plugin-curology.git#master",
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jest": "^26.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1556,6 +1556,10 @@ eslint-module-utils@^2.7.2:
     debug "^3.2.7"
     find-up "^2.1.0"
 
+"eslint-plugin-curology@https://github.com/curology/eslint-plugin-curology.git#master":
+  version "1.0.1"
+  resolved "https://github.com/curology/eslint-plugin-curology.git#8ae97ff7866b2999afb649e94f5a10e0d1a8d2fe"
+
 eslint-plugin-cypress@^2.12.1:
   version "2.12.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-cypress/-/eslint-plugin-cypress-2.12.1.tgz#9aeee700708ca8c058e00cdafe215199918c2632"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1556,9 +1556,10 @@ eslint-module-utils@^2.7.2:
     debug "^3.2.7"
     find-up "^2.1.0"
 
-"eslint-plugin-curology@https://github.com/curology/eslint-plugin-curology.git#master":
-  version "1.0.1"
-  resolved "https://github.com/curology/eslint-plugin-curology.git#8ae97ff7866b2999afb649e94f5a10e0d1a8d2fe"
+eslint-plugin-curology@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-curology/-/eslint-plugin-curology-1.0.2.tgz#a1b93dabfea2d5701f8cae7749bc59195cba1e2d"
+  integrity sha512-k/f2ZND5d5Ja6fU1bmsAnFANwzKnBKiaI24DsmFoMh2tBCY90LdxipS2a5aQ8iS0hcdKXYfCgGG+X8hYIah63Q==
 
 eslint-plugin-cypress@^2.12.1:
   version "2.12.1"


### PR DESCRIPTION
Our `recommend` config relies on a rule we define in this repo, which can make versioning a little confusing. #30 failed tests because while we updated the import path within this repo, but were still pointing to an official version rather than a git hash. I haven't figured out an ergonomic way to nest self-referencing eslint config like this.