### PR TITLE
Create `prefer-named-import` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,4 @@ Then configure the rules you want to use under the rules section.
 ## Supported Rules
 
 - [`no-single-letter-variable`](docs/rules/no-single-letter-variable.md): prevent a single letter variable declaration (included in `recommended` config)
+- [`prefer-named-import`](docs/rules/prefer-named-import.md): prefer named imports

--- a/docs/rules/prefer-named-import.md
+++ b/docs/rules/prefer-named-import.md
@@ -1,0 +1,41 @@
+# Prefer named imports (prefer-named-import)
+
+As a team, there are certain files that we'd prefer only named imports
+
+
+## Rule Details
+
+Using the following config when setting up your ESLint rule. Specify
+the paths of the files you'd prefer named imports from. If you leave 
+the paths array empty, it will assume you always want named imports.
+
+```json
+
+   "curology/no-default-import": [
+      2,
+      {
+        "paths": ["pathToCheckGoesHere", "."]
+        }
+      ],
+```
+
+Examples of **incorrect** code for this rule:
+
+```js
+
+import Module from '.';
+```
+
+Examples of **correct** code for this rule:
+
+```js
+
+import { Module } from '.';
+
+```
+
+## When Not To Use It
+
+A lot of external packages might not have a named export and instead only
+use a default export. It's important that you specify paths in the config
+so you don't get errors for these external packages.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-curology",
-  "version": "1.0.5",
+  "version": "1.0.4",
   "description": "ESLint Plugin and Configuration for Curology",
   "author": "Curology <engineering@curology.com>",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-curology",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "ESLint Plugin and Configuration for Curology",
   "author": "Curology <engineering@curology.com>",
   "keywords": [

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -1,5 +1,7 @@
 const noSingleLetterVariable = require("./no-single-letter-variable");
+const preferNamedImport = require("./prefer-named-import");
 
 module.exports = {
   "no-single-letter-variable": noSingleLetterVariable,
+  "prefer-named-import": preferNamedImport,
 };

--- a/src/rules/prefer-named-import/index.js
+++ b/src/rules/prefer-named-import/index.js
@@ -1,0 +1,66 @@
+/**
+ * @fileoverview Prefer named imports
+ * @author Alyssa Melendez
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: "Prefer named imports",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: undefined,
+    schema: [
+      {
+        type: "object",
+        properties: {
+          paths: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+            uniqueItems: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+
+  create: function (context) {
+    const restrictedPaths = context.options[0].paths;
+
+    function isRestrictedPath(importSource) {
+      let result = false;
+      restrictedPaths?.forEach((path) => {
+        if (importSource === path) result = true;
+      });
+
+      return result;
+    }
+
+    return {
+      ImportDeclaration(node) {
+        const importSource = node.source.value.trim();
+
+        if (
+          isRestrictedPath(importSource) &&
+          node.specifiers.forEach(function (specifier) {
+            if (specifier.type === "ImportDefaultSpecifier") {
+              context.report({
+                node,
+                message: `Please only use named imports for '${importSource}'`,
+              });
+            }
+          })
+        );
+      },
+    };
+  },
+};

--- a/src/rules/prefer-named-import/index.js
+++ b/src/rules/prefer-named-import/index.js
@@ -38,7 +38,7 @@ module.exports = {
 
     function isRestrictedPath(importSource) {
       let result = false;
-      restrictedPaths?.forEach((path) => {
+      restrictedPaths.forEach((path) => {
         if (importSource === path) result = true;
       });
 

--- a/src/rules/prefer-named-import/test.js
+++ b/src/rules/prefer-named-import/test.js
@@ -1,0 +1,75 @@
+/**
+ * @fileoverview Prefer named imports
+ * @author Alyssa Melendez
+ */
+"use strict";
+
+const path = require("path");
+const { RuleTester } = require("eslint");
+
+const preferNamedImportRule = require(".");
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const NODE_MODULES_PATH = "../../../node_modules";
+
+const ruleTester = new RuleTester({
+  parser: path.join(__dirname, NODE_MODULES_PATH, "@babel/eslint-parser"),
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: "module",
+    requireConfigFile: false,
+  },
+});
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const OPTIONS = [{ paths: [".", "./index"] }];
+
+ruleTester.run("prefer-named-import", preferNamedImportRule, {
+  valid: [
+    {
+      code: "import { Module } from '.';",
+      options: OPTIONS,
+    },
+    {
+      code: "import { Module } from './index';",
+      options: OPTIONS,
+    },
+    {
+      code: "import Module from 'components/modules/module';",
+      options: OPTIONS,
+    },
+    {
+      code: "import React from 'react';",
+      options: OPTIONS,
+    },
+  ],
+
+  invalid: [
+    {
+      code: "import Module from '.';",
+      options: OPTIONS,
+      errors: [
+        {
+          message: `Please only use named imports for '.'`,
+          type: "ImportDeclaration",
+        },
+      ],
+    },
+    {
+      code: "import Module from './index';",
+      options: OPTIONS,
+      errors: [
+        {
+          message: `Please only use named imports for './index'`,
+          type: "ImportDeclaration",
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
### What & Why
This PR creates the `prefer-named-import` rule. Use this rule if you want to ensure you're only using named imports for certain file paths.